### PR TITLE
Implement conversion to predg3f from pquvc

### DIFF
--- a/inc/cs2/predg3f.h
+++ b/inc/cs2/predg3f.h
@@ -53,6 +53,8 @@ CS2_API void cs2_predg3f_from_predh3f(struct cs2_predg3f_s *g, const struct cs2_
 CS2_API void cs2_predg3f_from_preds3f(struct cs2_predg3f_s *g, const struct cs2_preds3f_s *s);
 CS2_API void cs2_predg3f_pquv(struct cs2_vec3f_s *p, struct cs2_vec3f_s *q, struct cs2_vec3f_s *u, struct cs2_vec3f_s *v, const struct cs2_predg3f_s *g);
 
+CS2_API void cs2_predg3f_from_pquvc(struct cs2_predg3f_s *g, const struct cs2_vec3f_s *p, const struct cs2_vec3f_s *q, const struct cs2_vec3f_s *u, const struct cs2_vec3f_s *v, double c, double alpha, double beta);
+
 /* type */
 enum cs2_predgtype3f_e
 {

--- a/inc/cs2/rand.h
+++ b/inc/cs2/rand.h
@@ -44,8 +44,8 @@ CS2_API double cs2_rand_u1f(struct cs2_rand_s *r, double min, double max); /* un
 CS2_API int cs2_rand_1i(struct cs2_rand_s *r); /* uniform rand {0, 1} */
 CS2_API int cs2_rand_u1i(struct cs2_rand_s *r, int min, int max); /* uniform rand {min, ..., max} */
 
-CS2_API void cs2_rand_vec3f_1f(struct cs2_rand_s *r, struct cs2_vec3f_s *v); /* uniform rand vec3f [0; 1] */
-CS2_API void cs2_rand_vec3f_u1f(struct cs2_rand_s *r, struct cs2_vec3f_s *v, double min, double max); /* uniform rand vec3f [min; max] */
+CS2_API void cs2_rand_vec3f_1f(struct cs2_vec3f_s *v, struct cs2_rand_s *r); /* uniform rand vec3f [0; 1] */
+CS2_API void cs2_rand_vec3f_u1f(struct cs2_vec3f_s *v, struct cs2_rand_s *r, double min, double max); /* uniform rand vec3f [min; max] */
 
 CS2_API_END
 

--- a/src/predg3f.c
+++ b/src/predg3f.c
@@ -958,6 +958,24 @@ void cs2_predg3f_pquv(struct cs2_vec3f_s *p, struct cs2_vec3f_s *q, struct cs2_v
     cs2_vec3f_cross(v, &g->a, &g->b);
 }
 
+void cs2_predg3f_from_pquvc(struct cs2_predg3f_s *g, const struct cs2_vec3f_s *p, const struct cs2_vec3f_s *q, const struct cs2_vec3f_s *u, const struct cs2_vec3f_s *v, double c, double alpha, double beta)
+{
+    struct cs2_vec3f_s pxu, vxq;
+    double usl = cs2_vec3f_sqlen(u);
+    double qsl = cs2_vec3f_sqlen(q);
+
+    CS2_ASSERT(!_cs2_almost_zero(usl) && !_cs2_almost_zero(qsl));
+
+    cs2_vec3f_cross(&pxu, p, u);
+    cs2_vec3f_cross(&vxq, v, q);
+
+    cs2_vec3f_mad2(&g->l, u, alpha, &pxu, 1.0 / usl);
+    cs2_vec3f_add(&g->k, &g->l, u);
+    cs2_vec3f_mad2(&g->b, q, beta, &vxq, 1.0 / qsl);
+    cs2_vec3f_add(&g->a, &g->b, q);
+    g->c = c;
+}
+
 const char *cs2_predgtype3f_str(enum cs2_predgtype3f_e t)
 {
     switch (t)

--- a/src/rand.c
+++ b/src/rand.c
@@ -62,12 +62,12 @@ int cs2_rand_u1i(struct cs2_rand_s *r, int min, int max)
     return min + (double)_cs2_xorshift128plus(r) * (max - min) / UINT64_MAX; // fixme: overflow possble
 }
 
-void cs2_rand_vec3f_1f(struct cs2_rand_s *r, struct cs2_vec3f_s *v)
+void cs2_rand_vec3f_1f(struct cs2_vec3f_s *v, struct cs2_rand_s *r)
 {
     cs2_vec3f_set(v, cs2_rand_1f(r), cs2_rand_1f(r), cs2_rand_1f(r));
 }
 
-void cs2_rand_vec3f_u1f(struct cs2_rand_s *r, struct cs2_vec3f_s *v, double min, double max)
+void cs2_rand_vec3f_u1f(struct cs2_vec3f_s *v, struct cs2_rand_s *r, double min, double max)
 {
     cs2_vec3f_set(v, cs2_rand_u1f(r, min, max), cs2_rand_u1f(r, min, max), cs2_rand_u1f(r, min, max));
 }

--- a/test/inc/test/test.h
+++ b/test/inc/test/test.h
@@ -46,11 +46,12 @@ struct test_suite_s
     struct test_suite_s *next;
 };
 
+extern struct test_suite_s *test_suites_registry;
+
 #define TEST_SUITE_REGISTER(TestSuiteName) \
     static void test_suite_reg_##TestSuiteName(void) __attribute__((constructor)); \
     static void test_suite_reg_##TestSuiteName(void) \
     { \
-        extern struct test_suite_s *test_suites_registry; \
         if (!test_suites_registry) \
             test_suites_registry = &test_suite_##TestSuiteName; \
         else \


### PR DESCRIPTION
Convert characteristic g3 predicate vectors along with constant c to a g3 predicate for given equivalence class parameters alpha and beta